### PR TITLE
joy-media: fix build error

### DIFF
--- a/packages/joy-media/src/channels/ChannelHeader.tsx
+++ b/packages/joy-media/src/channels/ChannelHeader.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { BgImg } from '../common/BgImg';
 import { ChannelEntity } from '../entities/ChannelEntity';
 import { ChannelPreview } from './ChannelPreview';
+import { ChannelToFormValues } from '../schemas/channel/Channel';
 
 type Props = {
   channel: ChannelEntity
@@ -9,10 +10,10 @@ type Props = {
 
 export function ChannelHeader (props: Props) {
   const { channel } = props;
-
+  const channelFormValues = ChannelToFormValues(channel);
   return (
     <div className='ChannelHeader'>
-      <BgImg className='ChannelCover' url={channel.banner} />
+      <BgImg className='ChannelCover' url={channelFormValues.banner} />
       <ChannelPreview channel={channel} size='big' />
     </div>
   );

--- a/packages/joy-media/src/transport.substrate.ts
+++ b/packages/joy-media/src/transport.substrate.ts
@@ -14,7 +14,7 @@ import { MusicMoodType } from './schemas/music/MusicMood';
 import { MusicThemeType } from './schemas/music/MusicTheme';
 import { PublicationStatusType } from './schemas/general/PublicationStatus';
 import { VideoCategoryType } from './schemas/video/VideoCategory';
-import { MemberId } from '@joystream/types/lib/members';
+import { MemberId } from '@joystream/types/members';
 import { ChannelEntity } from './entities/ChannelEntity';
 import { ChannelId } from '@joystream/types/content-working-group';
 

--- a/packages/joy-media/src/transport.substrate.ts
+++ b/packages/joy-media/src/transport.substrate.ts
@@ -14,7 +14,7 @@ import { MusicMoodType } from './schemas/music/MusicMood';
 import { MusicThemeType } from './schemas/music/MusicTheme';
 import { PublicationStatusType } from './schemas/general/PublicationStatus';
 import { VideoCategoryType } from './schemas/video/VideoCategory';
-import { MemberId } from 'packages/joy-types/lib/members';
+import { MemberId } from '@joystream/types/lib/members';
 import { ChannelEntity } from './entities/ChannelEntity';
 import { ChannelId } from '@joystream/types/content-working-group';
 


### PR DESCRIPTION
Fixes ts compiler error when building:
```
joy-media/src/channels/ChannelHeader.tsx:15:39 - error TS2322: Type 'string | undefined' is not assignable to type 'string'.
  Type 'undefined' is not assignable to type 'string'.

      <BgImg className='ChannelCover' url={channel.banner} />
                                         ~~~

  joy-media/src/common/BgImg.tsx:4:3
       url: string,
       ~~~
    The expected type comes from property 'url' which is declared here on type 'IntrinsicAttributes & Props'
```

Maybe we want to have `ChannelToFormValues()` provide a default placeholder banner if one is not provided. But I will leave that to @siman just needed to fix the build for now.